### PR TITLE
fix: prefix inner types for safety

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -46,7 +46,7 @@ apiPromise.then(API => {
   linter.lint(outFile, output, configuration)
   const result = linter.getResult()
 
-  if (result.failureCount === 0) {
+  if (result.failureCount === 0 || process.argv.includes('--force-write')) {
     fs.writeFileSync(outFile, output)
   } else {
     console.error('Failed to lint electron.d.ts')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,6 +25,13 @@ const wrapComment = (comment) => {
   return result.concat(' */')
 }
 
+const prefixTypeForSafety = (type) => {
+  if (type !== 'Object' && typeof type === 'string' && !isPrimitive(type) && !isBuiltIn(type)) {
+    return `Electron.${type}`
+  }
+  return type
+}
+
 const typify = (type) => {
   // Capture some weird edge cases
   const originalType = type
@@ -105,7 +112,7 @@ const typify = (type) => {
       return '(() => void)'
     case 'promise':
       if (innerType) {
-        return `Promise<${typify(innerType[0])}>`
+        return `Promise<${prefixTypeForSafety(typify(innerType[0]))}>`
       }
       debug('Promise with missing inner type, defaulting to any')
       return 'Promise<any>'
@@ -156,7 +163,8 @@ const isPrimitive = (type) => {
     'boolean',
     'number',
     'any',
-    'string'
+    'string',
+    'void'
   ]
   return primitives.indexOf(type.toLowerCase().replace(/\[\]/g, '')) !== -1
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node cli.js",
-    "demo": "npm run build -- -o=electron.d.ts",
+    "demo": "npm run build -- -o=electron.d.ts --force-write",
     "prepublishOnly": "npm run demo && npm run test-output",
     "lint-output": "tslint -c tslint.json -t verbose electron.d.ts --fix",
     "test": "mocha && standard --fix && npm run demo && npm run test-output && npm run lint-output",

--- a/vendor/fetch-docs.js
+++ b/vendor/fetch-docs.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp').sync
 const os = require('os')
 
 const downloadPath = path.join(os.tmpdir(), 'electron-api-tmp')
-const ELECTRON_COMMIT = '241098c7d2fa04c5712c8f6512470a5249bb64b1'
+const ELECTRON_COMMIT = '2feb919143d3acd8c6cdd611e98be591db074a38'
 
 rm(downloadPath)
 


### PR DESCRIPTION
Required for https://github.com/electron/electron/pull/16593


`Promise<ElectronType>` becomes `Promise<Electron.ElectronType>`