### PR TITLE
Fix compilation error with the latest @types/node

### DIFF
--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -1,4 +1,4 @@
-  const EventEmitter: typeof import('events').EventEmitter;
+  const NodeEventEmitter: typeof import('events').EventEmitter;
 
   class Accelerator extends String {
 

--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -1,3 +1,5 @@
+  const EventEmitter: typeof import('events').EventEmitter;
+
   class Accelerator extends String {
 
   }

--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -47,7 +47,7 @@ export const generateModuleDeclaration = (
             (module.name === 'remote'
               ? 'MainInterface'
               : isClass
-              ? 'EventEmitter'
+              ? 'NodeEventEmitter'
               : 'NodeJS.EventEmitter')} {`,
         );
         moduleAPI.push('', `// Docs: ${module.websiteUrl}`, '');

--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -44,7 +44,11 @@ export const generateModuleDeclaration = (
           `${isClass ? 'class' : 'interface'} ${_.upperFirst(
             module.name,
           )} extends ${module.extends ||
-            (module.name === 'remote' ? 'MainInterface' : 'NodeJS.EventEmitter')} {`,
+            (module.name === 'remote'
+              ? 'MainInterface'
+              : isClass
+              ? 'EventEmitter'
+              : 'NodeJS.EventEmitter')} {`,
         );
         moduleAPI.push('', `// Docs: ${module.websiteUrl}`, '');
       } else {


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/21612

In the latest `@types/node`, `NodeJS.EventEmitter` was changed from class to interface. But some classes in `electron.d.ts` extend it (class cannot extend interface) so it causes a compilation error as I reported in above issue. This issue is not immediate because Electron's Node.js version is still v12. But fixing this issue is also valid for `@types/node@12`.

This patch fixes the issue with advice from @andrewbranch.

I confirmed above issue was resolved by `electron.d.ts` generated by this pull request branch (I had generated `electron-api.json` in the latest branch of electron repository).