### PR TITLE
fix: compilation error with @types/node@13 (which is now latest)

### DIFF
--- a/base/base_footer.ts
+++ b/base/base_footer.ts
@@ -1,6 +1,3 @@
-declare module 'electron' {
-  export = Electron;
-}
 
 interface NodeRequireFunction {
   (moduleName: 'electron'): typeof Electron;
@@ -13,11 +10,18 @@ interface File {
   path: string;
 }
 
+interface Document {
+  createElement(tagName: 'webview'): Electron.WebviewTag;
+}
+
+}
+
+declare module 'electron' {
+  export = Electron;
+}
+
 declare module 'original-fs' {
   import * as fs from 'fs';
   export = fs;
 }
 
-interface Document {
-  createElement(tagName: 'webview'): Electron.WebviewTag;
-}

--- a/base/base_header.ts
+++ b/base/base_header.ts
@@ -4,5 +4,8 @@
 // Definitions: https://github.com/electron/electron-typescript-definitions
 
 /// <reference types="node" />
+import events = require('events');
 
 type GlobalEvent = Event;
+
+declare global {

--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -44,7 +44,7 @@ export const generateModuleDeclaration = (
           `${isClass ? 'class' : 'interface'} ${_.upperFirst(
             module.name,
           )} extends ${module.extends ||
-            (module.name === 'remote' ? 'MainInterface' : 'NodeJS.EventEmitter')} {`,
+            (module.name === 'remote' ? 'MainInterface' : 'events.EventEmitter')} {`,
         );
         moduleAPI.push('', `// Docs: ${module.websiteUrl}`, '');
       } else {


### PR DESCRIPTION
Like #163, but compatible with versions of Typescript before 2.9. The diff is larger and uglier, however.

1. Explicitly `import events = require('events')`
2. Wrap everything in `declare global {` except pre-existing ambient modules 'electron' and 'original-fs'.
3. Refer to EventEmitter as events.EventEmitter instead of NodeJS.EventEmitter
4. Create a local alias for ReadableStream due to the way global merging works (which is badly, in this case).