### PR TITLE
fix: correct types for addEventListener, removeEventListener

### DIFF
--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -189,27 +189,34 @@ export const generateModuleDeclaration = (
           );
         }
 
-        for (let method of ['addEventListener', 'removeEventListener']) {
-          moduleAPI.push(
-            `${method}(event: '${domEvent.name}', listener: (event: ${eventType}) => void${
-              method === 'addEventListener' ? ', useCapture?: boolean' : ''
-            }): this;`,
-          );
-        }
+        moduleAPI.push(
+          `addEventListener(event: '${domEvent.name}', listener: (this: ${_.upperFirst(
+            module.name,
+          )}, event: ${eventType}) => void, options?: boolean | AddEventListenerOptions): void;`,
+        );
+        moduleAPI.push(
+          `removeEventListener(event: '${domEvent.name}', listener: (this: ${_.upperFirst(
+            module.name,
+          )}, event: ${eventType}) => void, options?: boolean | EventListenerOptions): void;`,
+        );
       });
 
       // original overloads copied from HTMLElement, because they are not inherited
       moduleAPI.push(
-        `addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;`,
+        `addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: ${_.upperFirst(
+          module.name,
+        )}, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;`,
       );
       moduleAPI.push(
-        `addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;`,
+        `addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;`,
       );
       moduleAPI.push(
-        `removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;`,
+        `removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: ${_.upperFirst(
+          module.name,
+        )}, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;`,
       );
       moduleAPI.push(
-        `removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;`,
+        `removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;`,
       );
     }
   }


### PR DESCRIPTION
`addEventListener` calls the listener with `this` bound to the target. It takes `options?: boolean | AddEventListenerOptions` rather than just `useCapture?: boolean` as its third parameter, and returns `void` rather than `this`.

`removeEventListener` is the same, except with `EventListenerOptions` instead of `AddEventListenerOptions`.

This follows the [current definitions](https://github.com/microsoft/TypeScript/blob/v4.4.4/lib/lib.dom.d.ts#L5206) from the TypeScript library.

<details>
<summary>Output difference</summary>

```diff
--- electron.d.ts.old	2021-10-08 17:31:24.484654176 -0700
+++ electron.d.ts	2021-10-08 17:52:13.028610203 -0700
@@ -11679,86 +11679,86 @@
      * document as well as subframe document-level loads, but does not include
      * asynchronous resource loads.
      */
-    addEventListener(event: 'load-commit', listener: (event: LoadCommitEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'load-commit', listener: (event: LoadCommitEvent) => void): this;
+    addEventListener(event: 'load-commit', listener: (this: WebviewTag, event: LoadCommitEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'load-commit', listener: (this: WebviewTag, event: LoadCommitEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the navigation is done, i.e. the spinner of the tab will stop
      * spinning, and the `onload` event is dispatched.
      */
-    addEventListener(event: 'did-finish-load', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-finish-load', listener: (event: Event) => void): this;
+    addEventListener(event: 'did-finish-load', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-finish-load', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * This event is like `did-finish-load`, but fired when the load failed or was
      * cancelled, e.g. `window.stop()` is invoked.
      */
-    addEventListener(event: 'did-fail-load', listener: (event: DidFailLoadEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-fail-load', listener: (event: DidFailLoadEvent) => void): this;
+    addEventListener(event: 'did-fail-load', listener: (this: WebviewTag, event: DidFailLoadEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-fail-load', listener: (this: WebviewTag, event: DidFailLoadEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when a frame has done navigation.
      */
-    addEventListener(event: 'did-frame-finish-load', listener: (event: DidFrameFinishLoadEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-frame-finish-load', listener: (event: DidFrameFinishLoadEvent) => void): this;
+    addEventListener(event: 'did-frame-finish-load', listener: (this: WebviewTag, event: DidFrameFinishLoadEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-frame-finish-load', listener: (this: WebviewTag, event: DidFrameFinishLoadEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Corresponds to the points in time when the spinner of the tab starts spinning.
      */
-    addEventListener(event: 'did-start-loading', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-start-loading', listener: (event: Event) => void): this;
+    addEventListener(event: 'did-start-loading', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-start-loading', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Corresponds to the points in time when the spinner of the tab stops spinning.
      */
-    addEventListener(event: 'did-stop-loading', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-stop-loading', listener: (event: Event) => void): this;
+    addEventListener(event: 'did-stop-loading', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-stop-loading', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when attached to the embedder web contents.
      */
-    addEventListener(event: 'did-attach', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-attach', listener: (event: Event) => void): this;
+    addEventListener(event: 'did-attach', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-attach', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when document in the given frame is loaded.
      */
-    addEventListener(event: 'dom-ready', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'dom-ready', listener: (event: Event) => void): this;
+    addEventListener(event: 'dom-ready', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'dom-ready', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when page title is set during navigation. `explicitSet` is false when
      * title is synthesized from file url.
      */
-    addEventListener(event: 'page-title-updated', listener: (event: PageTitleUpdatedEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'page-title-updated', listener: (event: PageTitleUpdatedEvent) => void): this;
+    addEventListener(event: 'page-title-updated', listener: (this: WebviewTag, event: PageTitleUpdatedEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'page-title-updated', listener: (this: WebviewTag, event: PageTitleUpdatedEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when page receives favicon urls.
      */
-    addEventListener(event: 'page-favicon-updated', listener: (event: PageFaviconUpdatedEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'page-favicon-updated', listener: (event: PageFaviconUpdatedEvent) => void): this;
+    addEventListener(event: 'page-favicon-updated', listener: (this: WebviewTag, event: PageFaviconUpdatedEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'page-favicon-updated', listener: (this: WebviewTag, event: PageFaviconUpdatedEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when page enters fullscreen triggered by HTML API.
      */
-    addEventListener(event: 'enter-html-full-screen', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'enter-html-full-screen', listener: (event: Event) => void): this;
+    addEventListener(event: 'enter-html-full-screen', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'enter-html-full-screen', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when page leaves fullscreen triggered by HTML API.
      */
-    addEventListener(event: 'leave-html-full-screen', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'leave-html-full-screen', listener: (event: Event) => void): this;
+    addEventListener(event: 'leave-html-full-screen', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'leave-html-full-screen', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the guest window logs a console message.
      *
      * The following example code forwards all log messages to the embedder's console
      * without regard for log level or other properties.
      */
-    addEventListener(event: 'console-message', listener: (event: ConsoleMessageEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'console-message', listener: (event: ConsoleMessageEvent) => void): this;
+    addEventListener(event: 'console-message', listener: (this: WebviewTag, event: ConsoleMessageEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'console-message', listener: (this: WebviewTag, event: ConsoleMessageEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when a result is available for `webview.findInPage` request.
      */
-    addEventListener(event: 'found-in-page', listener: (event: FoundInPageEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'found-in-page', listener: (event: FoundInPageEvent) => void): this;
+    addEventListener(event: 'found-in-page', listener: (this: WebviewTag, event: FoundInPageEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'found-in-page', listener: (this: WebviewTag, event: FoundInPageEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the guest page attempts to open a new browser window.
      *
      * The following example code opens the new url in system's default browser.
      */
-    addEventListener(event: 'new-window', listener: (event: NewWindowEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'new-window', listener: (event: NewWindowEvent) => void): this;
+    addEventListener(event: 'new-window', listener: (this: WebviewTag, event: NewWindowEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'new-window', listener: (this: WebviewTag, event: NewWindowEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when a user or the page wants to start navigation. It can happen when
      * the `window.location` object is changed or a user clicks a link in the page.
@@ -11772,14 +11772,14 @@
      *
      * Calling `event.preventDefault()` does __NOT__ have any effect.
      */
-    addEventListener(event: 'will-navigate', listener: (event: WillNavigateEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'will-navigate', listener: (event: WillNavigateEvent) => void): this;
+    addEventListener(event: 'will-navigate', listener: (this: WebviewTag, event: WillNavigateEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'will-navigate', listener: (this: WebviewTag, event: WillNavigateEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when any frame (including main) starts navigating. `isInPlace` will be
      * `true` for in-page navigations.
      */
-    addEventListener(event: 'did-start-navigation', listener: (event: DidStartNavigationEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-start-navigation', listener: (event: DidStartNavigationEvent) => void): this;
+    addEventListener(event: 'did-start-navigation', listener: (this: WebviewTag, event: DidStartNavigationEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-start-navigation', listener: (this: WebviewTag, event: DidStartNavigationEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when a navigation is done.
      *
@@ -11787,8 +11787,8 @@
      * or updating the `window.location.hash`. Use `did-navigate-in-page` event for
      * this purpose.
      */
-    addEventListener(event: 'did-navigate', listener: (event: DidNavigateEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-navigate', listener: (event: DidNavigateEvent) => void): this;
+    addEventListener(event: 'did-navigate', listener: (this: WebviewTag, event: DidNavigateEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-navigate', listener: (this: WebviewTag, event: DidNavigateEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when any frame navigation is done.
      *
@@ -11796,8 +11796,8 @@
      * or updating the `window.location.hash`. Use `did-navigate-in-page` event for
      * this purpose.
      */
-    addEventListener(event: 'did-frame-navigate', listener: (event: DidFrameNavigateEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-frame-navigate', listener: (event: DidFrameNavigateEvent) => void): this;
+    addEventListener(event: 'did-frame-navigate', listener: (this: WebviewTag, event: DidFrameNavigateEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-frame-navigate', listener: (this: WebviewTag, event: DidFrameNavigateEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when an in-page navigation happened.
      *
@@ -11805,79 +11805,79 @@
      * navigation outside of the page. Examples of this occurring are when anchor links
      * are clicked or when the DOM `hashchange` event is triggered.
      */
-    addEventListener(event: 'did-navigate-in-page', listener: (event: DidNavigateInPageEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-navigate-in-page', listener: (event: DidNavigateInPageEvent) => void): this;
+    addEventListener(event: 'did-navigate-in-page', listener: (this: WebviewTag, event: DidNavigateInPageEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-navigate-in-page', listener: (this: WebviewTag, event: DidNavigateInPageEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the guest page attempts to close itself.
      *
      * The following example code navigates the `webview` to `about:blank` when the
      * guest attempts to close itself.
      */
-    addEventListener(event: 'close', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'close', listener: (event: Event) => void): this;
+    addEventListener(event: 'close', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'close', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the guest page has sent an asynchronous message to embedder page.
      *
      * With `sendToHost` method and `ipc-message` event you can communicate between
      * guest page and embedder page:
      */
-    addEventListener(event: 'ipc-message', listener: (event: IpcMessageEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'ipc-message', listener: (event: IpcMessageEvent) => void): this;
+    addEventListener(event: 'ipc-message', listener: (this: WebviewTag, event: IpcMessageEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'ipc-message', listener: (this: WebviewTag, event: IpcMessageEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the renderer process is crashed.
      */
-    addEventListener(event: 'crashed', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'crashed', listener: (event: Event) => void): this;
+    addEventListener(event: 'crashed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'crashed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when a plugin process is crashed.
      */
-    addEventListener(event: 'plugin-crashed', listener: (event: PluginCrashedEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'plugin-crashed', listener: (event: PluginCrashedEvent) => void): this;
+    addEventListener(event: 'plugin-crashed', listener: (this: WebviewTag, event: PluginCrashedEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'plugin-crashed', listener: (this: WebviewTag, event: PluginCrashedEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Fired when the WebContents is destroyed.
      */
-    addEventListener(event: 'destroyed', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'destroyed', listener: (event: Event) => void): this;
+    addEventListener(event: 'destroyed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'destroyed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when media starts playing.
      */
-    addEventListener(event: 'media-started-playing', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'media-started-playing', listener: (event: Event) => void): this;
+    addEventListener(event: 'media-started-playing', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'media-started-playing', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when media is paused or done playing.
      */
-    addEventListener(event: 'media-paused', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'media-paused', listener: (event: Event) => void): this;
+    addEventListener(event: 'media-paused', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'media-paused', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when a page's theme color changes. This is usually due to encountering a
      * meta tag:
      */
-    addEventListener(event: 'did-change-theme-color', listener: (event: DidChangeThemeColorEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'did-change-theme-color', listener: (event: DidChangeThemeColorEvent) => void): this;
+    addEventListener(event: 'did-change-theme-color', listener: (this: WebviewTag, event: DidChangeThemeColorEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'did-change-theme-color', listener: (this: WebviewTag, event: DidChangeThemeColorEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when mouse moves over a link or the keyboard moves the focus to a link.
      */
-    addEventListener(event: 'update-target-url', listener: (event: UpdateTargetUrlEvent) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'update-target-url', listener: (event: UpdateTargetUrlEvent) => void): this;
+    addEventListener(event: 'update-target-url', listener: (this: WebviewTag, event: UpdateTargetUrlEvent) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'update-target-url', listener: (this: WebviewTag, event: UpdateTargetUrlEvent) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when DevTools is opened.
      */
-    addEventListener(event: 'devtools-opened', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'devtools-opened', listener: (event: Event) => void): this;
+    addEventListener(event: 'devtools-opened', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'devtools-opened', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when DevTools is closed.
      */
-    addEventListener(event: 'devtools-closed', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'devtools-closed', listener: (event: Event) => void): this;
+    addEventListener(event: 'devtools-closed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'devtools-closed', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
     /**
      * Emitted when DevTools is focused / opened.
      */
-    addEventListener(event: 'devtools-focused', listener: (event: Event) => void, useCapture?: boolean): this;
-    removeEventListener(event: 'devtools-focused', listener: (event: Event) => void): this;
-    addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
-    removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, useCapture?: boolean): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+    addEventListener(event: 'devtools-focused', listener: (this: WebviewTag, event: Event) => void, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(event: 'devtools-focused', listener: (this: WebviewTag, event: Event) => void, options?: boolean | EventListenerOptions): void;
+    addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: WebviewTag, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: WebviewTag, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     /**
      * Whether the guest page can go back.
      */
```
</details>