### PR TITLE
fix: pass param name to object typify

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -379,7 +379,10 @@ export const genMethodString = (
           } else if (paramType.type === 'Object' && objectParam.properties) {
             return {
               ...objectParam,
-              type: createMethodObjectParamType(objectParam),
+              type: createMethodObjectParamType({
+                ...objectParam,
+                name: param.name,
+              }),
             };
           }
           return paramType;


### PR DESCRIPTION
For a union type of a param where one part of the union is an Object type, we must retain the name of the object param so that typify has context on what to define the interface as.