### PR TITLE
feat: expose GlobalResponse for net.fetch

### DIFF
--- a/base/base_header.ts
+++ b/base/base_header.ts
@@ -6,3 +6,4 @@
 /// <reference types="node" />
 
 type GlobalEvent = Event & { returnValue: any };
+type GlobalResponse = Response;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -285,6 +285,7 @@ export const isBuiltIn = (type: string) => {
     'float64array',
     'bigint64array',
     'biguint64array',
+    'globalresponse',
   ];
   return builtIns.indexOf(type.toLowerCase().replace(/\[\]/g, '')) !== -1;
 };


### PR DESCRIPTION
net.fetch() needs to reference the Response object in Node.js. There's already
some object called 'Response' in the Electron namespace, and there's [no way to
escape a scope](https://github.com/Microsoft/TypeScript/issues/983) in
typescript, so here we go.
