### PR TITLE
feat: add new Event support for extensible params

### DIFF
--- a/base/base_header.ts
+++ b/base/base_header.ts
@@ -5,5 +5,5 @@
 
 /// <reference types="node" />
 
-type GlobalEvent = Event & { returnValue: any };
+type DOMEvent = Event;
 type GlobalResponse = Response;

--- a/base/base_inner.ts
+++ b/base/base_inner.ts
@@ -1,5 +1,10 @@
   const NodeEventEmitter: typeof import('events').EventEmitter;
 
-  class Accelerator extends String {
+  type EmptyParams = {};
+  type Event<Params extends object, Sender extends NodeJS.EventEmitter> = {
+    preventDefault: () => void;
+    readonly defaultPrevented: boolean;
+    sender: Sender;
+  } & Params;
 
-  }
+  class Accelerator extends String {}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^3.0.0",
-    "@electron/docs-parser": "^1.0.1",
+    "@electron/docs-parser": "^1.1.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.14.123",

--- a/src/dynamic-param-interfaces.ts
+++ b/src/dynamic-param-interfaces.ts
@@ -118,8 +118,7 @@ const flushParamInterfaces = (
       )
       .forEach(paramKey => {
         if (paramKey === 'Event') {
-          delete paramInterfacesToDeclare[paramKey];
-          return;
+          throw 'Unexpected dynamic Event type, should be routed through the Event handler';
         }
         if (declared[paramKey]) {
           const toDeclareCheck: ParamInterface = Object.assign(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,9 +28,9 @@ export const extendArray = <T>(arr1: T[], arr2: T[]): T[] => {
 };
 
 export const wrapComment = (comment: string, additionalTags: DocumentationTag[] = []): string[] => {
-  if (!comment) return [];
+  if (!comment && !additionalTags.length) return [];
   comment = comment.replace(/^\(optional\)(?: - )?/gi, '');
-  if (!comment) return [];
+  if (!comment && !additionalTags.length) return [];
   const result = ['/**'];
   while (comment.length > 0) {
     let index = 0;
@@ -48,7 +48,7 @@ export const wrapComment = (comment: string, additionalTags: DocumentationTag[] 
     comment = comment.substring(index + 1);
   }
   if (additionalTags.length) {
-    result.push(' *');
+    if (result.length > 1) result.push(' *');
     const nodePlatforms: string[] = [];
     result.push(
       ...additionalTags
@@ -241,7 +241,6 @@ export const paramify = (paramName: string) => {
 // TODO: Infer through electron-docs-linter/parser
 export const isEmitter = (module: Pick<ModuleDocumentationContainer, 'name'>) => {
   const nonEventEmitters = [
-    'menu',
     'menuitem',
     'nativeimage',
     'shell',

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     semver "^7.1.2"
     tempy "^1.0.0"
 
-"@electron/docs-parser@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.0.1.tgz#f9856d00ec1663a0fb6301f55bc674f44c7dc543"
-  integrity sha512-jqUHwo3MWUhWusHtTVpSHTZqWSVuc1sPUfavI5Zwdx64q7qd4phqOPGoxScWS3JthKt7Wydvo/eReIUNDJ0gRg==
+"@electron/docs-parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.1.0.tgz#ba095def41746bde56bee731feaf22272bf0b765"
+  integrity sha512-qrjIKJk8t4/xAYldDVNQgcF8zdAAuG260bzPxdh/xI3p/yddm61bftoct+Tx2crnWFnOfOkr6nGERsDknNiT8A==
   dependencies:
     "@types/markdown-it" "^12.0.0"
     chai "^4.2.0"


### PR DESCRIPTION
This adds support for the new event type blocks that https://github.com/electron/docs-parser/pull/80 generates. Specifically...

##### Inline Events

<details>

```json
{
  "name": "event",
  "description": "",
  "collection": false,
  "type": "Event",
  "eventProperties": [
    {
      "name": "url",
      "description": "The URL the frame is navigating to.",
      "required": true,
      "additionalTags": [],
      "collection": false,
      "type": "String",
      "possibleValues": null
    },
    {
      "name": "isSameDocument",
      "description": "Whether the navigation happened without changing document. Examples of same document navigations are reference fragment navigations, pushState/replaceState, and same page history navigation.",
      "required": true,
      "additionalTags": [],
      "collection": false,
      "type": "boolean"
    },
    {
      "name": "isMainFrame",
      "description": "True if the navigation is taking place in a main frame.",
      "required": true,
      "additionalTags": [],
      "collection": false,
      "type": "boolean"
    },
    {
      "name": "frame",
      "description": "The frame to be navigated.",
      "required": true,
      "additionalTags": [],
      "collection": false,
      "type": "WebFrameMain"
    },
    {
      "name": "initiator",
      "description": "The frame which initiated the navigation, which can be a parent frame (e.g. via `window.open` with a frame's name), or null if the navigation was not initiated by a frame. This can also be null if the initiating frame was deleted before the event was emitted.",
      "required": false,
      "additionalTags": [],
      "collection": false,
      "type": "WebFrameMain"
    }
  ],
  "additionalTags": [],
  "required": true
},
```

</details>

###### Structure Referenced Events

<details>

```json
{
  "name": "event",
  "description": "",
  "collection": false,
  "type": "Event",
  "eventPropertiesReference": {
    "collection": false,
    "type": "NavigationEventParams"
  },
  "additionalTags": [],
  "required": true
},
```
</details>

This is a pretty hefty change under the hood and it contains some other subtle fixes that will become more apparent in the archeologist output when this is landed into `electron/electron`.

* Things with empty comments but "deprecated" tags will now actually generate a tag comment.
* `Electron.Event` no longer **incorrectly** extends the DOM `Event` object.  It instead accurately defines itself as an isolated type.
* DOM Element events (e.g. webview) still extend `DOMEvent` correctly
* `sender` on `Event` is now typed correctly depending on the object emitting the event
* `menu` is flagged as an event emitter correctly
* function properties of structures are now fully typed instead of being loose `Function` types