### PR TITLE
chore: update references to previous repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to electron-typescript-definitions
+# Contributing to electron/typescript-definitions
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This module uses Electron's [JSON API documentation](https://github.com/electron/docs-parser) to produce a TypeScript definition file for the Electron API.
 
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/electron/typescript-definitions/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/electron/typescript-definitions/tree/main)
+[![npm version](http://img.shields.io/npm/v/@electron/typescript-definitions.svg)](https://npmjs.org/package/@electron/typescript-definitions)
 
 ## Installation
 
@@ -27,7 +28,7 @@ The module exports a function that parses a given API JSON object and returns
 an array of lines to create the definition file
 
 ```js
-const { generateDefinitions } = require('electron-typescript-definitions')
+const { generateDefinitions } = require('@electron/typescript-definitions')
 const apiPath = './vendor/electron/docs/api.json'
 
 const definitionLines = generateDefinitions({ electronApi: require(apiPath) })

--- a/base/base_header.ts
+++ b/base/base_header.ts
@@ -1,7 +1,7 @@
 // Type definitions for Electron <<VERSION>>
 // Project: http://electronjs.org/
 // Definitions by: The Electron Team <https://github.com/electron/electron>
-// Definitions: https://github.com/electron/electron-typescript-definitions
+// Definitions: https://github.com/electron/typescript-definitions
 
 /// <reference types="node" />
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/electron/electron-typescript-definitions.git"
+    "url": "https://github.com/electron/typescript-definitions.git"
   },
   "files": [
     "dist",


### PR DESCRIPTION
There were a few lingering references to `electron-typescript-definitions` as the repo name. Also added a status badge for the package because I like those.