### PR TITLE
chore: remove releases and upgrades from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @electron/wg-ecosystem @electron/wg-releases @electron/wg-upgrades
+* @electron/wg-ecosystem


### PR DESCRIPTION
makes it so that PRs to this repo are not blocked by releases and upgrades approval.