### PR TITLE
build: drop unused .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-electron-api-docs
-yarn.lock
-.npmrc
-.env


### PR DESCRIPTION
This package already has a `"files"` field in `package.json` so it wasn't making use of `.npmignore` anyway.

https://github.com/electron/typescript-definitions/blob/0b0c787be972ff048859d5911bb13b7a0af66a0a/package.json#L52-L56