### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,32 @@
 version: 2.1
+
 orbs:
   cfa: continuousauth/npm@1.0.2
-jobs:
-  test:
-    docker:
-      - image: cimg/node:14.21
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "yarn.lock" }}
-            - v1-dependencies-
-      - run: yarn install --ignore-engines
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
-      - run: yarn prettier:check
-      - run: yarn test
+  node: electronjs/node@1.4.1
+
 workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test
+      - node/test:
+          name: test-<< matrix.executor >>-<< matrix.node-version >>
+          override-ci-command: yarn install --frozen-lockfile --ignore-engines
+          test-steps:
+            - run: yarn prettier:check
+            - run: yarn test
+          use-test-steps: true
+          matrix:
+            alias: test
+            parameters:
+              executor:
+                - node/linux
+                - node/macos
+                - node/windows
+              node-version:
+                - '20.5'
+                - '18.17'
+                - '16.20'
+                - '14.21'
       - cfa/release:
           requires:
             - test


### PR DESCRIPTION
Use `electronjs/node` orb to pick up caching of Node.js installs, and expand the test matrix.