### PR TITLE
fix: spread sub type onto parent type for dynamic param interface

### DIFF
--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -386,7 +386,7 @@ export const generateModuleDeclaration = (
                   type: DynamicParamInterfaces.createParamInterface(
                     {
                       ...p,
-                      type: t,
+                      ...t,
                     } as any,
                     '',
                   ),


### PR DESCRIPTION
Fixes https://github.com/electron/electron/issues/39790