### PR TITLE
feat: add electron/utility module for utility process

### DIFF
--- a/base/base_footer.ts
+++ b/base/base_footer.ts
@@ -14,11 +14,16 @@ declare module 'electron/renderer' {
   export = Electron.Renderer;
 }
 
+declare module 'electron/utility' {
+  export = Electron.Utility;
+}
+
 interface NodeRequireFunction {
   (moduleName: 'electron'): typeof Electron.CrossProcessExports;
   (moduleName: 'electron/main'): typeof Electron.Main;
   (moduleName: 'electron/common'): typeof Electron.Common;
   (moduleName: 'electron/renderer'): typeof Electron.Renderer;
+  (moduleName: 'electron/utility'): typeof Electron.Utility;
 }
 
 interface NodeRequire {
@@ -26,6 +31,7 @@ interface NodeRequire {
   (moduleName: 'electron/main'): typeof Electron.Main;
   (moduleName: 'electron/common'): typeof Electron.Common;
   (moduleName: 'electron/renderer'): typeof Electron.Renderer;
+  (moduleName: 'electron/utility'): typeof Electron.Utility;
 }
 
 interface File {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^3.0.0",
-    "@electron/docs-parser": "^1.1.0",
+    "@electron/docs-parser": "^1.2.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.14.123",

--- a/src/primary-interfaces.ts
+++ b/src/primary-interfaces.ts
@@ -13,6 +13,7 @@ export const generatePrimaryInterfaces = (
   const CommonNamespace = ['namespace Common {', eventExport];
   const MainNamespace = ['namespace Main {', eventExport];
   const RendererNamespace = ['namespace Renderer {', eventExport];
+  const UtilityNamespace = ['namespace Utility {', eventExport];
   const MainInterfaceForRemote = ['interface RemoteMainInterface {'];
   const CrossProcessExportsNamespace = ['namespace CrossProcessExports {', eventExport];
   const constDeclarations: string[] = [];
@@ -102,9 +103,10 @@ export const generatePrimaryInterfaces = (
     }
     if (TargetNamespace) {
       debug(classify(module.name).toLowerCase(), EMRI[classify(module.name).toLowerCase()]);
-      if (!EMRI[classify(module.name).toLowerCase()]) {
-        if (moduleString) TargetNamespace.push(moduleString);
-        if (moduleString) CrossProcessExportsNamespace.push(moduleString);
+      if (!EMRI[classify(module.name).toLowerCase()] && moduleString) {
+        TargetNamespace.push(moduleString);
+        CrossProcessExportsNamespace.push(moduleString);
+        if (module.process.utility) UtilityNamespace.push(moduleString);
       }
       EMRI[classify(module.name).toLowerCase()] = true;
       const declarations = [...newConstDeclarations, ...newTypeAliases].map(
@@ -112,6 +114,7 @@ export const generatePrimaryInterfaces = (
       );
       TargetNamespace.push(...declarations);
       CrossProcessExportsNamespace.push(...declarations);
+      if (module.process.utility) UtilityNamespace.push(...declarations);
     }
   });
 
@@ -122,12 +125,14 @@ export const generatePrimaryInterfaces = (
     CommonNamespace.push(alias);
     MainNamespace.push(alias);
     RendererNamespace.push(alias);
+    UtilityNamespace.push(alias);
     CrossProcessExportsNamespace.push(alias);
   }
 
   CommonNamespace.push('}');
   MainNamespace.push('}');
   RendererNamespace.push('}');
+  UtilityNamespace.push('}');
   CrossProcessExportsNamespace.push('}');
 
   const withSemicolons = (lines: string[]) => {
@@ -137,6 +142,7 @@ export const generatePrimaryInterfaces = (
   addToOutput(withSemicolons(CommonNamespace));
   addToOutput(withSemicolons(MainNamespace));
   addToOutput(withSemicolons(RendererNamespace));
+  addToOutput(withSemicolons(UtilityNamespace));
   addToOutput(withSemicolons(CrossProcessExportsNamespace));
   addToOutput(constDeclarations);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,10 @@
     semver "^7.1.2"
     tempy "^1.0.0"
 
-"@electron/docs-parser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.1.0.tgz#ba095def41746bde56bee731feaf22272bf0b765"
-  integrity sha512-qrjIKJk8t4/xAYldDVNQgcF8zdAAuG260bzPxdh/xI3p/yddm61bftoct+Tx2crnWFnOfOkr6nGERsDknNiT8A==
+"@electron/docs-parser@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@electron/docs-parser/-/docs-parser-1.2.0.tgz#dc3032012dd270c667777e097e185d92e7ff86ef"
+  integrity sha512-Rz/lMLRDSvEshYNmSC30v/3rk7Mj6EL/76wraKvfM5XvYPHsmApo9CedvcJNNMm7+Rc29NOohoqA4B2/XtFm1Q==
   dependencies:
     "@types/markdown-it" "^12.0.0"
     chai "^4.2.0"


### PR DESCRIPTION
This adds a `'electron/utility'` module for modules available to the utility process.

This PR depends on https://github.com/electron/docs-parser/pull/95 in order to add the `ProcessBlock.utility` property.

Opting to make the change in a minimal way to not interfere with the main+renderer=common logic and just add the additional `Utility` with just the minimal set of exports available to the utility process.

See https://github.com/electron/electron/pull/40017 for an example of adding new API to the utility process that will need this change.