### PR TITLE
fix: ensure Electron.Utility property exists

### DIFF
--- a/src/primary-interfaces.ts
+++ b/src/primary-interfaces.ts
@@ -106,6 +106,8 @@ export const generatePrimaryInterfaces = (
     }
   });
 
+  constDeclarations.push('const Utility: {};');
+
   for (const interfaceKey of interfaceKeys) {
     const alias = `  type ${interfaceKey} = Electron.${interfaceKey}`;
     CommonNamespace.push(alias);

--- a/src/primary-interfaces.ts
+++ b/src/primary-interfaces.ts
@@ -33,6 +33,8 @@ export const generatePrimaryInterfaces = (
     }
   };
 
+  let utilityNamespaceHasValues = false;
+
   API.forEach((module, index) => {
     if (module.name === 'process') return;
     let TargetNamespace;
@@ -102,11 +104,18 @@ export const generatePrimaryInterfaces = (
       );
       TargetNamespace.push(...declarations);
       CrossProcessExportsNamespace.push(...declarations);
-      if (module.process.utility) UtilityNamespace.push(...declarations);
+      if (module.process.utility) {
+        UtilityNamespace.push(...declarations);
+        if (newConstDeclarations.length > 0) {
+          utilityNamespaceHasValues = true;
+        }
+      }
     }
   });
 
-  constDeclarations.push('const Utility: {};');
+  if (!utilityNamespaceHasValues) {
+    constDeclarations.push('const Utility: {};');
+  }
 
   for (const interfaceKey of interfaceKeys) {
     const alias = `  type ${interfaceKey} = Electron.${interfaceKey}`;


### PR DESCRIPTION
Added in #246, the Utility namespace currently has no concrete values in it on electron/electron@main. This change ensures Electron.Utility is available as a property even when the namespace has no values.

Takes advantage of declaration merging: https://www.typescriptlang.org/docs/handbook/declaration-merging.html

Other approaches considered:
- Separating out the values from each namespace into interfaces and setting properties for each interface.
  - Decided this was too invasive for questionable value
- Adding a dummy value to the Utility namespace to ensure it's never empty.
  - Decided too much of a hack and dummy value would be visible to end users

Tested with `node spec/ts-smoke/runner.js` on electron/electron@main

Should unblock https://github.com/electron/electron/pull/40264 to ultimately be used (and made not empty) in https://github.com/electron/electron/pull/40017