### PR TITLE
chore: remove obsolete support for the remote module

### DIFF
--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -57,12 +57,7 @@ export const generateModuleDeclaration = (
         moduleAPI.push(
           `${isClass ? 'class' : 'interface'} ${_.upperFirst(
             module.name,
-          )} extends ${module.extends ||
-            (module.name === 'remote'
-              ? 'RemoteMainInterface'
-              : isClass
-              ? 'NodeEventEmitter'
-              : 'NodeJS.EventEmitter')} {`,
+          )} extends ${module.extends || (isClass ? 'NodeEventEmitter' : 'NodeJS.EventEmitter')} {`,
         );
         moduleAPI.push('', `// Docs: ${module.websiteUrl}`, '');
       } else {

--- a/src/primary-interfaces.ts
+++ b/src/primary-interfaces.ts
@@ -14,7 +14,6 @@ export const generatePrimaryInterfaces = (
   const MainNamespace = ['namespace Main {', eventExport];
   const RendererNamespace = ['namespace Renderer {', eventExport];
   const UtilityNamespace = ['namespace Utility {', eventExport];
-  const MainInterfaceForRemote = ['interface RemoteMainInterface {'];
   const CrossProcessExportsNamespace = ['namespace CrossProcessExports {', eventExport];
   const constDeclarations: string[] = [];
   const EMRI: Record<string, boolean> = {};
@@ -90,17 +89,6 @@ export const generatePrimaryInterfaces = (
     } else if (module.process.renderer) {
       TargetNamespace = RendererNamespace;
     }
-    if (
-      module.process.main &&
-      module.process.exported &&
-      !EMRI[classify(module.name).toLowerCase()]
-    ) {
-      MainInterfaceForRemote.push(
-        `  ${classify(module.name)}: ${
-          isClass || isModuleButActuallyStaticClass ? 'typeof ' : ''
-        }${_.upperFirst(module.name)};`,
-      );
-    }
     if (TargetNamespace) {
       debug(classify(module.name).toLowerCase(), EMRI[classify(module.name).toLowerCase()]);
       if (!EMRI[classify(module.name).toLowerCase()] && moduleString) {
@@ -117,8 +105,6 @@ export const generatePrimaryInterfaces = (
       if (module.process.utility) UtilityNamespace.push(...declarations);
     }
   });
-
-  addToOutput([...MainInterfaceForRemote, '}']);
 
   for (const interfaceKey of interfaceKeys) {
     const alias = `  type ${interfaceKey} = Electron.${interfaceKey}`;


### PR DESCRIPTION
The remote module is now using its own https://github.com/electron/remote/blob/main/index.d.ts