### PR TITLE
ci: tidy up config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ workflows:
     jobs:
       - node/test:
           name: test-<< matrix.executor >>-<< matrix.node-version >>
-          override-ci-command: yarn install --frozen-lockfile --ignore-engines
           pre-steps:
             - when:
                 condition:
@@ -31,8 +30,8 @@ workflows:
                 - node/macos
                 - node/windows
               node-version:
-                - '20.9'
-                - '18.17'
+                - '20.10'
+                - '18.18'
                 - '16.20'
                 # Stay below 14.17.0 or nvm tries to download arm64 artifacts which don't exist
                 - '14.16'


### PR DESCRIPTION
`--ignore-engines` is no longer needed, and bump Node.js versions to latest patch versions.