### PR TITLE
fix: event declaration additional tags

### DIFF
--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -180,7 +180,11 @@ export const generateModuleDeclaration = (
           listener = `(${args.join(`,\n${indent}`)}) => void`;
         }
 
-        for (let method of ['on', 'off', 'once', 'addListener', 'removeListener']) {
+        const methods = ['on', 'off', 'once', 'addListener', 'removeListener'];
+        for (const method of methods) {
+          if (methods.indexOf(method) > 0) {
+            utils.extendArray(moduleAPI, utils.wrapComment('', moduleEvent.additionalTags));
+          }
           moduleAPI.push(`${method}(event: '${moduleEvent.name}', listener: ${listener}): this;`);
         }
       });
@@ -220,7 +224,11 @@ export const generateModuleDeclaration = (
           );
         }
 
-        for (let method of ['addEventListener', 'removeEventListener']) {
+        const methods = ['addEventListener', 'removeEventListener'];
+        for (const method of methods) {
+          if (methods.indexOf(method) > 0) {
+            utils.extendArray(moduleAPI, utils.wrapComment('', domEvent.additionalTags));
+          }
           moduleAPI.push(
             `${method}(event: '${domEvent.name}', listener: (event: ${eventType}) => void${
               method === 'addEventListener' ? ', useCapture?: boolean' : ''

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect;
 const utils = require('../dist/utils');
+const { DocumentationTag } = require('@electron/docs-parser');
 
 describe('utils', () => {
   describe('extendArray', () => {
@@ -55,6 +56,14 @@ describe('utils', () => {
         'Unregisters the app from notifications received from APNS. See: https://developer.apple.com/documentation/appkit/nsapplication/1428747-unregisterforremotenotifications?language=objc',
       );
       expect(wrapped.length).equal(4);
+    });
+
+    it('should create a tag-only comment', () => {
+      const wrapped = utils.wrapComment('', [DocumentationTag.STABILITY_DEPRECATED]);
+      expect(wrapped.length).equal(3);
+      expect(wrapped[0]).to.be.equal('/**');
+      expect(wrapped[1].endsWith('@deprecated')).to.eq(true);
+      expect(wrapped[wrapped.length - 1]).to.be.equal(' */');
     });
   });
 


### PR DESCRIPTION
Regarding the comment for the event declaration, it seems that the `@deprecated` tag description does not follow JSDoc rules because it is written for multiple methods at once.
https://jsdoc.app/tags-deprecated.html
https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#deprecated
https://github.com/typescript-eslint/typescript-eslint/issues/1223

With the current output format, some methods are not detected by ESLint ([eslint-plugin-deprecation](https://github.com/gund/eslint-plugin-deprecation)) error checking, so it may be difficult to notice when an event you are using is deprecated.
I think it would be better to be able to emit the `@deprecated` tag for each method so that ESLint can check all usage of deprecated events.

**Before correction:**

```TSX
/**
  * Emitted when the renderer process crashes or is killed.
  *
  * **Deprecated:** This event is superceded by the `render-process-gone` event
  * which contains more information about why the render process disappeared.
  * isn't always because it crashed. The `killed` boolean can be replaced by
  * checking `reason === 'killed'` when you switch to that event.
  *
  * @deprecated
  */
on(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
off(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
once(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
addListener(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
removeListener(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
```

**Revised:**

```TSX
/**
  * Emitted when the renderer process crashes or is killed.
  *
  * **Deprecated:** This event is superceded by the `render-process-gone` event
  * which contains more information about why the render process disappeared.
  * isn't always because it crashed. The `killed` boolean can be replaced by
  * checking `reason === 'killed'` when you switch to that event.
  *
  * @deprecated
  */
on(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
/**
  * @deprecated
  */
off(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
/**
  * @deprecated
  */
once(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
/**
  * @deprecated
  */
addListener(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
/**
  * @deprecated
  */
removeListener(event: 'crashed', listener: (event: Event,
                                 killed: boolean) => void): this;
```
