### PR TITLE
fix: move @electron/docs-parser to runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@electron/docs-parser": "^1.2.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.14.123",
@@ -33,6 +32,7 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
+    "@electron/docs-parser": "^1.2.0",
     "@types/node": "^11.13.7",
     "chalk": "^2.4.2",
     "colors": "^1.1.2",

--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -13,7 +13,6 @@ import {
   DetailedFunctionType,
   ElementDocumentationContainer,
   DocumentationTag,
-  PropertyDocumentationBlock,
   DetailedEventType,
   DetailedEventReferenceType,
 } from '@electron/docs-parser';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import {
   TypeInformation,
   DetailedStringType,


### PR DESCRIPTION
I think this is technically more correct. I noticed that `npx @electron/typescript-definitions` will fail due to docs-parser being a dev dependency.

```
> npx @electron/typescript-definitions
Need to install the following packages:
@electron/typescript-definitions@8.15.3
Ok to proceed? (y) y
node:internal/modules/cjs/loader:1080
  throw err;
  ^

Error: Cannot find module '@electron/docs-parser'
Require stack:
- /Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/utils.js
- /Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/index.js
- /Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/bin.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (/Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/utils.js:6:23)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/utils.js',
    '/Users/erick.zhao/.npm/_npx/2a5658ae8c272926/node_modules/@electron/typescript-definitions/dist/index.js',
```