### PR TITLE
fix: infer EventEmitter extensions from API

### DIFF
--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -116,11 +116,18 @@ describe('utils', () => {
 
   describe('isEmitter', () => {
     it('should return true on most modules', () => {
-      expect(utils.isEmitter({ name: 'app' })).to.eq(true);
+      expect(utils.isEmitter({ name: 'app', type: 'Module', events: [1] })).to.eq(true);
     });
 
     it('should return false for specific non-emitter modules', () => {
-      expect(utils.isEmitter({ name: 'menuitem' })).to.eq(false);
+      expect(
+        utils.isEmitter({
+          name: 'menuitem',
+          type: 'Class',
+          instanceEvents: [],
+          instanceMethods: [],
+        }),
+      ).to.eq(false);
     });
   });
 


### PR DESCRIPTION
Instead of hard-coding a list of modules, we now infer if a module/class is an eventemitter with the following heuristic:
* If the module / class has any events it's an emitter
* If the module / class exposes `on`, `once` and `removeListener` it's an emitter (e.g. `ipcMain`)

This correctly identifies several exposed interfaces as not being emitters and improves the type safety of newly added modules