### PR TITLE
chore: add  `engines.node` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "electron-typescript-definitions": "dist/bin.js"
   },
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "build": "tsc",
     "prepare": "husky install",


### PR DESCRIPTION
https://github.com/mochajs/mocha/blob/5f96d511dbf913f135b92198aab721a27f6b44fe/package.json#L47C14-L47C23

Minimum for our mocha runner. All tests pass on this version.