### PR TITLE
fix: emit listeners with no params explicitly

### DIFF
--- a/src/module-declaration.ts
+++ b/src/module-declaration.ts
@@ -100,7 +100,7 @@ export const generateModuleDeclaration = (
         );
         let listener = 'Function';
 
-        if (moduleEvent.parameters && moduleEvent.parameters.length) {
+        if (moduleEvent.parameters) {
           const args: string[] = [];
           const indent = _.repeat(' ', moduleEvent.name.length + 29);
 


### PR DESCRIPTION
This seems to have been an oversight from the original implementation, having zero parameters is valid and `() => void` is way better than `Function`.

`Function` is effectively `any` when it comes to calling / binding and such