### PR TITLE
feat: allow custom types with inner types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,6 +255,8 @@ export const typify = (
       // we'll have to qualify it with the Node.js namespace.
       return 'NodeJS.ReadableStream';
   }
+  // Custom type
+  if (innerTypes) return `${typeAsString}<${typify(innerTypes[0])}>`;
   return typeAsString;
 };
 export const paramify = (paramName: string) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,7 +256,8 @@ export const typify = (
       return 'NodeJS.ReadableStream';
   }
   // Custom type
-  if (innerTypes) return `${typeAsString}<${typify(innerTypes[0])}>`;
+  if (innerTypes)
+    return `${typeAsString}<${innerTypes.map((innerType) => typify(innerType)).join(', ')}>`;
   return typeAsString;
 };
 export const paramify = (paramName: string) => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -116,6 +116,23 @@ describe('utils', () => {
           type: 'Foo',
         }),
       ).toEqual('Foo<T>');
+
+      expect(
+        utils.typify({
+          collection: false,
+          innerTypes: [
+            {
+              collection: false,
+              type: 'A',
+            },
+            {
+              collection: false,
+              type: 'B',
+            },
+          ],
+          type: 'Foo',
+        }),
+      ).toEqual('Foo<A, B>');
     });
   });
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -102,6 +102,21 @@ describe('utils', () => {
     it('should map node objects to the correct type', () => {
       expect(utils.typify('buffer')).toEqual('Buffer');
     });
+
+    it('should convert custom types with inner types', () => {
+      expect(
+        utils.typify({
+          collection: false,
+          innerTypes: [
+            {
+              collection: false,
+              type: 'T',
+            },
+          ],
+          type: 'Foo',
+        }),
+      ).toEqual('Foo<T>');
+    });
   });
 
   describe('paramify', () => {


### PR DESCRIPTION
I'm considering making some of the IPC types support generics for https://github.com/electron/rfcs/pull/8. While experimenting, I noticed we don't generate them for custom types.