### PR TITLE
fix: remove `File.path`

### DIFF
--- a/base/base_footer.ts
+++ b/base/base_footer.ts
@@ -34,13 +34,6 @@ interface NodeRequire {
   (moduleName: 'electron/utility'): typeof Electron.Utility;
 }
 
-interface File {
-  /**
-   * The real path to the file on the users filesystem
-   */
-  path: string;
-}
-
 declare module 'original-fs' {
   import * as fs from 'fs';
   export = fs;


### PR DESCRIPTION
`File.path` has been removed since Electron v32 but the type still remains.
Removing solely `File.path` would result in empty interface `File`; removing the whole inferface sounds better.

https://www.electronjs.org/docs/latest/breaking-changes#removed-filepath
https://github.com/electron/electron/pull/42053