### PR TITLE
fix: add null to primitives

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -293,7 +293,7 @@ export const isEmitter = (doc: ParsedDocumentationResult[0]) => {
   return false;
 };
 export const isPrimitive = (type: string) => {
-  const primitives = ['boolean', 'number', 'any', 'string', 'void', 'unknown'];
+  const primitives = ['boolean', 'number', 'any', 'string', 'void', 'null', 'unknown'];
   return primitives.indexOf(type.toLowerCase().replace(/\[\]/g, '')) !== -1;
 };
 export const isBuiltIn = (type: string) => {


### PR DESCRIPTION
Was trying to type `Promise<null>` and found it resolved to `Promise<Electron.null>`