### PR TITLE
fix: don't prefix undefined since it's a primitive

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -293,7 +293,7 @@ export const isEmitter = (doc: ParsedDocumentationResult[0]) => {
   return false;
 };
 export const isPrimitive = (type: string) => {
-  const primitives = ['boolean', 'number', 'any', 'string', 'void', 'null', 'unknown'];
+  const primitives = ['boolean', 'number', 'any', 'string', 'void', 'null', 'unknown', 'undefined'];
   return primitives.indexOf(type.toLowerCase().replace(/\[\]/g, '')) !== -1;
 };
 export const isBuiltIn = (type: string) => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -135,6 +135,21 @@ describe('utils', () => {
         }),
       ).toEqual('Foo<A, B>');
     });
+
+    it('should convert a Promise<undefined>', () => {
+      expect(
+        utils.typify({
+          collection: false,
+          innerTypes: [
+            {
+              collection: false,
+              type: 'undefined',
+            },
+          ],
+          type: 'Promise',
+        }),
+      ).toEqual('Promise<undefined>');
+    });
   });
 
   describe('paramify', () => {


### PR DESCRIPTION
The return type of `Promise<undefined>` actually comes up a decent amount in Web spec typings, so let's ensure we can support that typing for better alignment.