### PR TITLE
fix: don't inappropriately prefix if promise has multiple inner types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ const prefixTypeForSafety = (type: string) => {
     typeof type === 'string' &&
     !isPrimitive(type) &&
     !isBuiltIn(type) &&
-    !/\(\| /gi.test(type)
+    !/[\(\| ]/gi.test(type)
   ) {
     return `Electron.${type}`;
   }

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -104,6 +104,30 @@ describe('utils', () => {
       expect(utils.typify('buffer')).toEqual('Buffer');
     });
 
+    it('should convert a promise with multiple inner types', () => {
+      expect(
+        utils.typify({
+          collection: false,
+          innerTypes: [
+            {
+              collection: false,
+              type: [
+                {
+                  collection: false,
+                  type: 'number',
+                },
+                {
+                  collection: false,
+                  type: 'null',
+                },
+              ],
+            },
+          ],
+          type: 'Promise',
+        }),
+      ).toEqual('Promise<(number) | (null)>');
+    });
+
     it('should convert custom types with inner types', () => {
       expect(
         utils.typify({


### PR DESCRIPTION
Looks like the check added in #234 that intended to catch this edge case was slightly off, so when multiple types are involved you'd end up with things like `Promise<Electron.(number) | (null)>`.